### PR TITLE
Fixed Hostname Inconsistencies

### DIFF
--- a/config/graylog2_rails.yml
+++ b/config/graylog2_rails.yml
@@ -1,5 +1,5 @@
 default:
-  hostname: 127.0.0.1
+  host: 127.0.0.1
   port: 12201
   local_app_name: rails_application
   facility: rails_application

--- a/lib/generators/graylog2_rails/templates/config.erb
+++ b/lib/generators/graylog2_rails/templates/config.erb
@@ -1,5 +1,5 @@
 default: &defaults
-  hostname: 127.0.0.1
+  host: 127.0.0.1
   port: 12201
   max_chunk_size: LAN
   level: 3

--- a/lib/graylog2-rails/middleware.rb
+++ b/lib/graylog2-rails/middleware.rb
@@ -38,7 +38,7 @@ module Graylog2Rails
         Rails.logger.info "[GRAYLOG] [#{Time.now.utc.to_datetime}] #{args.inspect}"
 
         unless Rails.env.development? || Rails.env.test?
-          notifier = GELF::Notifier.new(@args.delete("hostname"), @args.delete("port"), @args.delete("max_chunk_size"))
+          notifier = GELF::Notifier.new(@args.delete("host"), @args.delete("port"), @args.delete("max_chunk_size"))
           notifier.notify!(args)
         end
       rescue => i_err

--- a/lib/graylog2-rails/version.rb
+++ b/lib/graylog2-rails/version.rb
@@ -1,3 +1,3 @@
 module Graylog2Rails
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
There were some config key inconsistencies. This is a fix so both the middleware and the notifier get the right data.
